### PR TITLE
workaround: bootdevice get not linked

### DIFF
--- a/recovery/root/etc/twrp.fstab
+++ b/recovery/root/etc/twrp.fstab
@@ -1,12 +1,12 @@
 # mount_point   fstype    device                                             flags
 
-/boot           emmc      /dev/block/bootdevice/by-name/boot
-/cache          ext4      /dev/block/bootdevice/by-name/cache
-/data           f2fs      /dev/block/bootdevice/by-name/userdata             flags=fsflags="inline_xattr";length=-16384
-/firmware       ext4      /dev/block/bootdevice/by-name/modem                flags=display="Firmware";fsflags=ro;mounttodecrypt
-/recovery       emmc      /dev/block/bootdevice/by-name/recovery             flags=backup=1
-/misc           emmc      /dev/block/bootdevice/by-name/misc
-/system         ext4      /dev/block/bootdevice/by-name/system
+/boot           emmc      /dev/block/platform/msm_sdcc.1/by-name/boot
+/cache          ext4      /dev/block/platform/msm_sdcc.1/by-name/cache
+/data           f2fs      /dev/block/platform/msm_sdcc.1/by-name/userdata             flags=fsflags="inline_xattr";length=-16384
+/firmware       ext4      /dev/block/platform/msm_sdcc.1/by-name/modem                flags=display="Firmware";fsflags=ro;mounttodecrypt
+/recovery       emmc      /dev/block/platform/msm_sdcc.1/by-name/recovery             flags=backup=1
+/misc           emmc      /dev/block/platform/msm_sdcc.1/by-name/misc
+/system         ext4      /dev/block/platform/msm_sdcc.1/by-name/system
 
 /sdcard1        auto      /dev/block/mmcblk1p1     /dev/block/mmcblk1        flags=display="MicroSD Card";storage;wipeingui;removable
 /usb-otg        auto      /dev/block/sda1          /dev/block/sda            flags=display="USB OTG";storage;wipeingui;removable


### PR DESCRIPTION
the fix would be to find out why bootdevice get not linked.
it may be due to this:

load_utags ERR opening (/dev/block/platform/msm_sdcc.1/by-name/utags) errno=2

as the kernel cmdline refers to it:
[...] utags.blkdev=/dev/block/platform/msm_sdcc.1/by-name/utags [...]